### PR TITLE
Update apoth configs

### DIFF
--- a/src/config/apotheosis/deadly.cfg
+++ b/src/config/apotheosis/deadly.cfg
@@ -21,7 +21,7 @@ bosses {
     B:"Fire Resistance"=true
 
     # The level up chance, this is rolled once per number of levels.  Levels determine gear. [range: 0.0 ~ 2.14748365E9, default: 0.4]
-    S:"Level Up Chance"=0.5
+    S:"Level Up Chance"=0.35
 
     # The max amount of extra damage bosses do, in half hearts. [range: 0.0 ~ 2.14748365E9, default: 3.0]
     S:"Max Damage Bonus"=5.0

--- a/src/config/apotheosis/deadly.cfg
+++ b/src/config/apotheosis/deadly.cfg
@@ -21,7 +21,7 @@ bosses {
     B:"Fire Resistance"=true
 
     # The level up chance, this is rolled once per number of levels.  Levels determine gear. [range: 0.0 ~ 2.14748365E9, default: 0.4]
-    S:"Level Up Chance"=0.35
+    S:"Level Up Chance"=0.5
 
     # The max amount of extra damage bosses do, in half hearts. [range: 0.0 ~ 2.14748365E9, default: 3.0]
     S:"Max Damage Bonus"=5.0

--- a/src/config/apotheosis/deadly.cfg
+++ b/src/config/apotheosis/deadly.cfg
@@ -13,7 +13,6 @@ bosses {
         2@minecraft:zombie_villager
 		2@minecraft:stray
         1@minecraft:zombie_pigman
-		1@ebwizardry:evil_wizard
         1@minecraft:wither_skeleton
      >
 
@@ -89,7 +88,6 @@ bosses {
 		1@minecraft:husk
 		1@minecraft:vex
 		1@minecraft:slime
-		1@ebwizardry:evil_wizard
         1@apotheosis:random
      >
 }

--- a/src/config/apotheosis/deadly.cfg
+++ b/src/config/apotheosis/deadly.cfg
@@ -7,45 +7,65 @@ bosses {
 
     # The possible mob types for bosses.  Format is weight@entity, entity is a registry name. [default: [4@minecraft:zombie], [3@minecraft:skeleton], [2@minecraft:spider], [1@minecraft:cave_spider], [1@minecraft:creeper], [1@minecraft:wither_skeleton]]
     S:"Boss Spawner Mobs" <
-        4@minecraft:zombie
+        3@minecraft:zombie
         3@minecraft:skeleton
-        2@minecraft:spider
-        1@minecraft:cave_spider
-        1@minecraft:creeper
+        2@minecraft:husk
+        2@minecraft:zombie_villager
+		2@minecraft:stray
+        1@minecraft:zombie_pigman
+		1@ebwizardry:evil_wizard
         1@minecraft:wither_skeleton
      >
 
-    # The amount of extra damage bosses do, in half hearts. [range: 0.0 ~ 2.14748365E9, default: 4.0]
-    S:"Damage Bonus"=4.0
-
-    # If bosses have fire resistance. [default: true]
+    # The percent chance a boss has fire resistance. [range: 0.0 ~ 3.4028235E38, default: 0.5]
     B:"Fire Resistance"=true
 
-    # The amount boss health is multiplied by.  Base hp * factor = final hp. [range: 0.0 ~ 2.14748365E9, default: 4.0]
-    S:"Health Multiplier"=4.0
+    # The level up chance, this is rolled once per number of levels.  Levels determine gear. [range: 0.0 ~ 2.14748365E9, default: 0.4]
+    S:"Level Up Chance"=0.5
 
-    # The amount of knockback resist bosses have. [range: 0.0 ~ 2.14748365E9, default: 0.85]
-    S:"Knockback Resist"=0.85
+    # The max amount of extra damage bosses do, in half hearts. [range: 0.0 ~ 2.14748365E9, default: 3.0]
+    S:"Max Damage Bonus"=5.0
 
-    # The level up chance, this is rolled once per number of levels.  Levels determine gear. [range: 0.0 ~ 2.14748365E9, default: 0.25]
-    S:"Level Up Chance"=0.25
+    # The max amount boss health is multiplied by.  Base hp * factor = final hp. [range: 0.0 ~ 2.14748365E9, default: 10.0]
+    S:"Max Health Multiplier"=25.0
+
+    # The max amount of knockback resist bosses have. [range: 0.0 ~ 2.14748365E9, default: 1.0]
+    S:"Max Knockback Resist"=1.0
+
+    # The max regeneration level of bosses. [range: 0.0 ~ 2.14748365E9, default: 2.0]
+    S:"Max Regen Level"=2.0
+
+    # The max resistance level of bosses. [range: 0.0 ~ 2.14748365E9, default: 2.0]
+    S:"Max Resistance Level"=2.0
+
+    # The max amount boss speed is multiplied by.  Base speed * factor = final speed. [range: 0.0 ~ 2.14748365E9, default: 1.5]
+    S:"Max Speed Multiplier"=1.75
+
+    # The min amount of extra damage bosses do, in half hearts. [range: 0.0 ~ 2.14748365E9, default: 1.2]
+    S:"Min Damage Bonus"=0.9
+
+    # The min amount boss health is multiplied by.  Base hp * factor = final hp. [range: 0.0 ~ 2.14748365E9, default: 2.5]
+    S:"Min Health Multiplier"=2.5
+
+    # The min amount of knockback resist bosses have. [range: 0.0 ~ 2.14748365E9, default: 0.5]
+    S:"Min Knockback Resist"=0.5
+
+    # The min regeneration level of bosses. [range: 0.0 ~ 2.14748365E9, default: 0.0]
+    S:"Min Regen Level"=0.0
+
+    # The min resistance level of bosses. [range: 0.0 ~ 2.14748365E9, default: 0.0]
+    S:"Min Resistance Level"=0.0
+
+    # The min amount boss speed is multiplied by.  Base speed * factor = final speed. [range: 0.0 ~ 2.14748365E9, default: 1.0]
+    S:"Min Speed Multiplier"=1.0
 
     # The chance a gear piece will be randomly enchanted. [range: 0.0 ~ 2.14748365E9, default: 0.25]
-    S:"Random Enchantment Chance"=0.25
+    S:"Random Enchantment Chance"=0.35
 
     # The chance a boss will have extra random potion effects. [range: 0.0 ~ 2.14748365E9, default: 0.45]
     S:"Random Potion Chance"=0.45
 
-    # The regeneration level of bosses.  Set to 0 to disable. [range: 0 ~ 2147483647, default: 2]
-    I:"Regen Level"=2
-
-    # The resistance level of bosses.  Set to 0 to disable. [range: 0 ~ 2147483647, default: 1]
-    I:"Resistance Level"=1
-
-    # The amount boss speed is multiplied by.  Base speed * factor = final speed. [range: 0.0 ~ 2.14748365E9, default: 1.15]
-    S:"Speed Multiplier"=1.15
-
-    # If bosses have water breathing. [default: true]
+    # The percent chance a boss has water breathing. [range: 0.0 ~ 3.4028235E38, default: 1.0]
     B:"Water Breathing"=true
 }
 
@@ -65,9 +85,11 @@ bosses {
     S:"Brutal Spawner Mobs" <
         4@minecraft:zombie
         1@minecraft:skeleton
-        1@minecraft:spider
-        1@minecraft:cave_spider
         1@minecraft:creeper
+		1@minecraft:husk
+		1@minecraft:vex
+		1@minecraft:slime
+		1@ebwizardry:evil_wizard
         1@apotheosis:random
      >
 }
@@ -75,7 +97,7 @@ bosses {
 
 dungeons {
     # The chance for a dungeon to have a brutal spawner. [range: 0.0 ~ 1.0, default: 0.05]
-    S:"Dungeon Brutal Chance"=0.05
+    S:"Dungeon Brutal Chance"=0.07
 
     # The chance for a dungeon to have a swarm spawner. [range: 0.0 ~ 1.0, default: 0.1]
     S:"Dungeon Swarm Chance"=0.1
@@ -84,7 +106,7 @@ dungeons {
 
 frequencies {
     # The chance (per chunk) for a boss to try spawning. [range: 0.0 ~ 1.0, default: 0.08]
-    S:"Boss Chance"=0.08
+    S:"Boss Chance"=0.09
 
     # The chance (per chunk) for a brutal spawner to try spawning. [range: 0.0 ~ 1.0, default: 0.12]
     S:"Brutal Spawner Chance"=0.12
@@ -95,7 +117,7 @@ frequencies {
 
 
 general {
-    # The biomes that the deadly module will not generate in. [default: [minecraft:ocean, minecraft:deep_ocean]]
+    # The biomes that the deadly module will not generate in. [default: [minecraft:warm_ocean], [minecraft:lukewarm_ocean], [minecraft:cold_ocean], [minecraft:frozen_ocean], [minecraft:deep_warm_ocean], [minecraft:deep_frozen_ocean], [minecraft:deep_lukewarm_ocean], [minecraft:deep_cold_ocean], [minecraft:ocean], [minecraft:deep_ocean]]
     S:"Generation Biome Blacklist" <
         minecraft:ocean, minecraft:deep_ocean
      >
@@ -108,16 +130,533 @@ general {
 
 
 "random spawners" {
-    I:"aether_legacy:aerwhale"=1
-    I:"aether_legacy:cockatrice"=1
-    I:"aether_legacy:fire_minion"=1
-    I:"aether_legacy:mimic"=1
-    I:"aether_legacy:sentry"=1
-    I:"aether_legacy:sun_spirit"=1
-    I:"aether_legacy:valkyrie"=1
-    I:"aether_legacy:valkyrie_queen"=1
-    I:"aether_legacy:whirlwind"=1
-    I:"aether_legacy:zephyr"=1
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:aw_npc_bard"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:aw_npc_combat"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:aw_npc_courier"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:aw_npc_priest"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:aw_npc_siege_engineer"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:aw_npc_trader"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:aw_npc_worker"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.archer"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.archer.elite"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.bard"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.cavalry"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.civilian.female"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.civilian.male"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.leader"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.leader.elite"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.mounted_archer"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.priest"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.siege_engineer"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.soldier"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.soldier.elite"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ancientwarfarenpc:faction.trader"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_alpine"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_angora"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_chinchilla"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_cottontail"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_dutch"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_fainting"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_havana"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_jack"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_kiko"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_kinder"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_lop"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_new_zealand"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_nigerian_dwarf"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_pygmy"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:buck_rex"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:bull_angus"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:bull_friesian"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:bull_hereford"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:bull_highland"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:bull_holstein"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:bull_jersey"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:bull_longhorn"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:bull_mooshroom"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:calf_angus"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:calf_friesian"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:calf_hereford"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:calf_highland"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:calf_holstein"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:calf_jersey"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:calf_longhorn"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:calf_mooshroom"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:chick_leghorn"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:chick_orpington"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:chick_plymouth_rock"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:chick_rhode_island_red"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:chick_wyandotte"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:cow_angus"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:cow_friesian"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:cow_hereford"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:cow_highland"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:cow_holstein"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:cow_jersey"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:cow_longhorn"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:cow_mooshroom"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:dartfrog"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_alpine"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_angora"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_chinchilla"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_cottontail"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_dutch"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_fainting"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_havana"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_jack"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_kiko"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_kinder"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_lop"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_new_zealand"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_nigerian_dwarf"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_pygmy"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:doe_rex"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ewe_dorper"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ewe_dorset"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ewe_friesian"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ewe_jacob"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ewe_merino"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ewe_suffolk"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ferret_grey"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ferret_white"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:foal_draft"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:frog"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hamster"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hedgehog"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hedgehog_albino"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hen_leghorn"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hen_orpington"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hen_plymouth_rock"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hen_rhode_island_red"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hen_wyandotte"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hog_duroc"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hog_hampshire"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hog_large_black"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hog_large_white"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hog_old_spot"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:hog_yorkshire"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kid_alpine"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kid_angora"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kid_fainting"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kid_kiko"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kid_kinder"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kid_nigerian_dwarf"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kid_pygmy"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kit_chinchilla"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kit_cottontail"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kit_dutch"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kit_havana"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kit_jack"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kit_lop"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kit_new_zealand"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:kit_rex"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:lamb_dorper"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:lamb_dorset"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:lamb_friesian"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:lamb_jacob"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:lamb_merino"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:lamb_suffolk"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:mare_draft"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peachick_blue"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peachick_charcoal"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peachick_opal"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peachick_peach"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peachick_purple"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peachick_taupe"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peachick_white"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peacock_blue"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peacock_charcoal"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peacock_opal"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peacock_peach"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peacock_purple"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peacock_taupe"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peacock_white"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peahen_blue"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peahen_charcoal"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peahen_opal"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peahen_peach"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peahen_purple"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peahen_taupe"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:peahen_white"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:piglet_duroc"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:piglet_hampshire"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:piglet_large_black"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:piglet_large_white"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:piglet_old_spot"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:piglet_yorkshire"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ram_dorper"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ram_dorset"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ram_friesian"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ram_jacob"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ram_merino"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:ram_suffolk"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:rooster_leghorn"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:rooster_orpington"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:rooster_plymouth_rock"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:rooster_rhode_island_red"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:rooster_wyandotte"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:sow_duroc"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:sow_hampshire"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:sow_large_black"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:sow_large_white"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:sow_old_spot"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:sow_yorkshire"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:stallion_draft"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"animania:toad"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"astralsorcery:entityflare"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"astralsorcery:entityliquidspark"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"astralsorcery:entityspectraltool"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"beneath:shadow"=1
@@ -126,16 +665,31 @@ general {
     I:"biomesoplenty:wasp"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"botania:doppleganger"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"botania:pink_wither"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"botania:pixie"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"chococraft:chocobo"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"ebwizardry:blaze_minion"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ebwizardry:decoy"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"ebwizardry:evil_wizard"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"ebwizardry:husk_minion"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ebwizardry:ice_giant"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"ebwizardry:ice_wraith"=1
@@ -147,6 +701,12 @@ general {
     I:"ebwizardry:magic_slime"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"ebwizardry:phoenix"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ebwizardry:shadow_wraith"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"ebwizardry:silverfish_minion"=1
 
     #  [range: 0 ~ 50, default: 1]
@@ -154,6 +714,15 @@ general {
 
     #  [range: 0 ~ 50, default: 1]
     I:"ebwizardry:spider_minion"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ebwizardry:spirit_horse"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ebwizardry:spirit_wolf"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"ebwizardry:storm_elemental"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"ebwizardry:stray_minion"=1
@@ -165,7 +734,19 @@ general {
     I:"ebwizardry:wither_skeleton_minion"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"ebwizardry:wizard"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"ebwizardry:zombie_minion"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.animated_bamboo_crate"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.animated_block"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.animated_chest"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.antlion"=1
@@ -178,6 +759,15 @@ general {
 
     #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.bed_bug"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.beetle"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.beetle_larva"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.black_ant"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.black_widow"=1
@@ -204,6 +794,12 @@ general {
     I:"erebus:erebus.chameleon_tick"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.cicada"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.crop_weevil"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.crushroom"=1
 
     #  [range: 0 ~ 50, default: 1]
@@ -214,6 +810,24 @@ general {
 
     #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.fire_ant_soldier"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.fly"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.fungal_weevil"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.gas_vent"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.glow_worm"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.grasshopper"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.honey_pot_ant"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.jumping_spider"=1
@@ -237,6 +851,9 @@ general {
     I:"erebus:erebus.mosquito"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.moth"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.pond_skater"=1
 
     #  [range: 0 ~ 50, default: 1]
@@ -244,6 +861,9 @@ general {
 
     #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.punchroom"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.rhino_beetle"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.scorpion"=1
@@ -258,6 +878,9 @@ general {
     I:"erebus:erebus.solifuge_small"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.stag_beetle"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.tarantula"=1
 
     #  [range: 0 ~ 50, default: 1]
@@ -267,6 +890,12 @@ general {
     I:"erebus:erebus.tarantula_mini_boss"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.titan_beetle"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.umber_golem"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.umber_golem_idol"=1
 
     #  [range: 0 ~ 50, default: 1]
@@ -274,6 +903,12 @@ general {
 
     #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.wasp"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.woodlouse"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"erebus:erebus.worker_bee"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"erebus:erebus.zombie_ant"=1
@@ -300,13 +935,25 @@ general {
     I:"icbmclassic:zombie.xmas.elf"=1
 
     #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:bat"=8
+
+    #  [range: 0 ~ 50, default: 8]
     I:"minecraft:blaze"=8
 
     #  [range: 0 ~ 50, default: 8]
     I:"minecraft:cave_spider"=8
 
     #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:chicken"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:cow"=8
+
+    #  [range: 0 ~ 50, default: 8]
     I:"minecraft:creeper"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:donkey"=8
 
     #  [range: 0 ~ 50, default: 8]
     I:"minecraft:elder_guardian"=8
@@ -333,13 +980,43 @@ general {
     I:"minecraft:guardian"=8
 
     #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:horse"=8
+
+    #  [range: 0 ~ 50, default: 8]
     I:"minecraft:husk"=8
 
     #  [range: 0 ~ 50, default: 8]
     I:"minecraft:illusion_illager"=8
 
     #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:llama"=8
+
+    #  [range: 0 ~ 50, default: 8]
     I:"minecraft:magma_cube"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:mooshroom"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:mule"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:ocelot"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:parrot"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:pig"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:polar_bear"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:rabbit"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:sheep"=8
 
     #  [range: 0 ~ 50, default: 8]
     I:"minecraft:shulker"=8
@@ -351,16 +1028,31 @@ general {
     I:"minecraft:skeleton"=8
 
     #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:skeleton_horse"=8
+
+    #  [range: 0 ~ 50, default: 8]
     I:"minecraft:slime"=8
 
     #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:snowman"=8
+
+    #  [range: 0 ~ 50, default: 8]
     I:"minecraft:spider"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:squid"=8
 
     #  [range: 0 ~ 50, default: 8]
     I:"minecraft:stray"=8
 
     #  [range: 0 ~ 50, default: 8]
     I:"minecraft:vex"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:villager"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:villager_golem"=8
 
     #  [range: 0 ~ 50, default: 8]
     I:"minecraft:vindication_illager"=8
@@ -375,13 +1067,22 @@ general {
     I:"minecraft:wither_skeleton"=8
 
     #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:wolf"=8
+
+    #  [range: 0 ~ 50, default: 8]
     I:"minecraft:zombie"=8
+
+    #  [range: 0 ~ 50, default: 8]
+    I:"minecraft:zombie_horse"=8
 
     #  [range: 0 ~ 50, default: 8]
     I:"minecraft:zombie_pigman"=8
 
     #  [range: 0 ~ 50, default: 8]
     I:"minecraft:zombie_villager"=8
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"mowziesmobs:baby_foliaath"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"mowziesmobs:barako"=1
@@ -408,7 +1109,31 @@ general {
     I:"mowziesmobs:frostmaw"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"mowziesmobs:grottol"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"mowziesmobs:lantern"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"mowziesmobs:naga"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"openblocks:luggage"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"openblocks:mini_me"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"oresheepmod:ore sheep"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"pneumaticcraft:drone"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"pneumaticcraft:harvesting_drone"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"pneumaticcraft:logistic_drone"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"rats:black_death"=1
@@ -438,6 +1163,12 @@ general {
     I:"rats:plague_cloud"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"rats:plague_doctor"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"rats:rat"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"rats:ratlantean_spirit"=1
 
     #  [range: 0 ~ 50, default: 1]
@@ -450,10 +1181,16 @@ general {
     I:"thebetweenlands:barrishee"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:blind_cave_fish"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:blood_snail"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:boulder_sprite"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:cc_ground_spawner"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:chiromaw"=1
@@ -465,6 +1202,9 @@ general {
     I:"thebetweenlands:dark_druid"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:dragonfly"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:dreadful_mummy"=1
 
     #  [range: 0 ~ 50, default: 1]
@@ -472,6 +1212,12 @@ general {
 
     #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:emberling_shaman"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:firefly"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:flame_jet"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:fortress_boss"=1
@@ -486,7 +1232,16 @@ general {
     I:"thebetweenlands:fortress_boss_turret"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:frog"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:gas_cloud"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:gecko"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:greebling"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:large_sludge_worm"=1
@@ -498,13 +1253,25 @@ general {
     I:"thebetweenlands:lurker"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:mire_snail"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:mire_snail_egg"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:moving_spawner_hole"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:mummy_arm"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:peat_mummy"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:pyrad"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:root_sprite"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:shambler"=1
@@ -531,6 +1298,12 @@ general {
     I:"thebetweenlands:spirit_tree_face_small"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:splodeshroom"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:sporeling"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:swamp_hag"=1
 
     #  [range: 0 ~ 50, default: 1]
@@ -540,6 +1313,9 @@ general {
     I:"thebetweenlands:tar_beast"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:tarminion"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:termite"=1
 
     #  [range: 0 ~ 50, default: 1]
@@ -547,6 +1323,18 @@ general {
 
     #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:tiny_sludge_worm_helper"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:tiny_worm_egg_sac"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:toad"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:triggered_falling_block"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"thebetweenlands:triggered_sludge_wall_jet"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"thebetweenlands:wall_lamprey"=1
@@ -574,16 +1362,31 @@ general {
     I:"twilightforest:armored_giant"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:bighorn_sheep"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:blockchain_goblin"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:boggard"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:bunny"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:castle_guardian"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:death_tome"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:deer"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:fire_beetle"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:firefly"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:giant_miner"=1
@@ -610,6 +1413,9 @@ general {
     I:"twilightforest:hydra"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:hydra_head"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:ice_crystal"=1
 
     #  [range: 0 ~ 50, default: 1]
@@ -626,6 +1432,9 @@ general {
 
     #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:lich_minion"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:loyal_zombie"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:maze_slime"=1
@@ -649,7 +1458,16 @@ general {
     I:"twilightforest:naga"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:penguin"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:pinch_beetle"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:quest_ram"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:raven"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:redcap"=1
@@ -676,10 +1494,16 @@ general {
     I:"twilightforest:snow_queen"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:squirrel"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:stable_ice_core"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:swarm_spider"=1
+
+    #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:tiny_bird"=1
 
     #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:tower_broodling"=1
@@ -703,6 +1527,9 @@ general {
     I:"twilightforest:ur_ghast"=1
 
     #  [range: 0 ~ 50, default: 1]
+    I:"twilightforest:wild_boar"=1
+
+    #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:winter_wolf"=1
 
     #  [range: 0 ~ 50, default: 1]
@@ -713,28 +1540,24 @@ general {
 
     #  [range: 0 ~ 50, default: 1]
     I:"twilightforest:yeti_alpha"=1
-    I:"wizardry:spirit_blight"=1
-    I:"wizardry:spirit_wight"=1
-    I:"wizardry:summon_zombie"=1
-    I:"wizardry:unicorn"=1
 }
 
 
 "spawner stats: brutal spawners" {
     # The maximum delay between spawns [range: 1 ~ 32767, default: 400]
-    I:"Max Delay"=400
+    I:"Max Delay"=600
 
     # The maximum number of nearby entities (when hit, the spawner turns off). [range: 1 ~ 32767, default: 6]
     I:"Max Nearby Entities"=6
 
     # The minimum delay between spawns [range: 1 ~ 32767, default: 200]
-    I:"Min Delay"=200
+    I:"Min Delay"=100
 
     # The required distance a player must be within for this spawner to work. [range: 1 ~ 32767, default: 16]
     I:"Player Range"=16
 
     # The number of mobs that will spawn. [range: 1 ~ 32767, default: 6]
-    I:"Spawn Count"=6
+    I:"Spawn Count"=8
 
     # The delay before first spawn on this spawner. [range: 1 ~ 32767, default: 20]
     I:"Spawn Delay"=20
@@ -746,19 +1569,19 @@ general {
 
 "spawner stats: swarm spawners" {
     # The maximum delay between spawns [range: 1 ~ 32767, default: 300]
-    I:"Max Delay"=300
+    I:"Max Delay"=100
 
     # The maximum number of nearby entities (when hit, the spawner turns off). [range: 1 ~ 32767, default: 32]
     I:"Max Nearby Entities"=32
 
     # The minimum delay between spawns [range: 1 ~ 32767, default: 75]
-    I:"Min Delay"=75
+    I:"Min Delay"=20
 
     # The required distance a player must be within for this spawner to work. [range: 1 ~ 32767, default: 8]
     I:"Player Range"=8
 
     # The number of mobs that will spawn. [range: 1 ~ 32767, default: 8]
-    I:"Spawn Count"=8
+    I:"Spawn Count"=4
 
     # The delay before first spawn on this spawner. [range: 1 ~ 32767, default: 20]
     I:"Spawn Delay"=20
@@ -771,10 +1594,10 @@ general {
 "swarm spawners" {
     # The possible spawn entries for swarm spawners.  Format is weight@entity, entity is a registry name. [default: [4@minecraft:zombie], [2@minecraft:skeleton], [5@minecraft:spider], [8@minecraft:cave_spider], [1@minecraft:creeper]]
     S:"Swarm Spawner Mobs" <
-        4@minecraft:zombie
-        2@minecraft:skeleton
-        5@minecraft:spider
-        8@minecraft:cave_spider
+		2@minecraft:stray
+        4@minecraft:spider
+        4@minecraft:cave_spider
+		4@minecraft:slime
         1@minecraft:creeper
      >
 }

--- a/src/config/apotheosis/enchantments.cfg
+++ b/src/config/apotheosis/enchantments.cfg
@@ -387,7 +387,7 @@
     I:"Max Level"=1
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
+    S:"Max Power Function"=0
 
     # The min level of this enchantment. [range: 1 ~ 127, default: 1]
     I:"Min Level"=1
@@ -402,7 +402,7 @@
     I:"Max Level"=17
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
+    S:"Max Power Function"=0
 
     # The min level of this enchantment. [range: 1 ~ 127, default: 1]
     I:"Min Level"=1
@@ -492,7 +492,7 @@
     I:"Max Level"=25
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
+    S:"Max Power Function"=0
 
     # The min level of this enchantment. [range: 1 ~ 127, default: 1]
     I:"Min Level"=1
@@ -537,7 +537,7 @@
     I:"Max Level"=1
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
+    S:"Max Power Function"=0
 
     # The min level of this enchantment. [range: 1 ~ 127, default: 1]
     I:"Min Level"=1
@@ -552,7 +552,7 @@
     I:"Max Level"=17
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
+    S:"Max Power Function"=0
 
     # The min level of this enchantment. [range: 1 ~ 127, default: 1]
     I:"Min Level"=1
@@ -567,7 +567,7 @@
     I:"Max Level"=20
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
+    S:"Max Power Function"=0
 
     # The min level of this enchantment. [range: 1 ~ 127, default: 1]
     I:"Min Level"=1
@@ -582,7 +582,7 @@
     I:"Max Level"=1
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
+    S:"Max Power Function"=0
 
     # The min level of this enchantment. [range: 1 ~ 127, default: 1]
     I:"Min Level"=1
@@ -1167,7 +1167,7 @@
     I:"Max Level"=17
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
+    S:"Max Power Function"=0
 
     # The min level of this enchantment. [range: 1 ~ 127, default: 1]
     I:"Min Level"=1
@@ -1197,7 +1197,7 @@
     I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
+    S:"Max Power Function"=0
 
     # The min level of this enchantment. [range: 1 ~ 127, default: 1]
     I:"Min Level"=1
@@ -1212,7 +1212,7 @@
     I:"Max Level"=17
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
+    S:"Max Power Function"=0
 
     # The min level of this enchantment. [range: 1 ~ 127, default: 1]
     I:"Min Level"=1
@@ -1227,7 +1227,7 @@
     I:"Max Level"=1
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
+    S:"Max Power Function"=0
 
     # The min level of this enchantment. [range: 1 ~ 127, default: 1]
     I:"Min Level"=1

--- a/src/config/apotheosis/enchantments.cfg
+++ b/src/config/apotheosis/enchantments.cfg
@@ -999,16 +999,16 @@
 
 "minecraft:silk_touch" {
     # The max level of this enchantment. [range: 1 ~ 127, default: 1]
-    I:"Max Level"=1
+    I:"Max Level"=2
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
+    S:"Max Power Function"=15 + 50 * (x - 1)
 
     # The min level of this enchantment. [range: 1 ~ 127, default: 1]
     I:"Min Level"=1
 
     # A function to determine the min enchanting power. [default: ]
-    S:"Min Power Function"=
+    S:"Min Power Function"=65 + 50 * (x - 1)
 }
 
 

--- a/src/config/apotheosis/names.cfg
+++ b/src/config/apotheosis/names.cfg
@@ -56,6 +56,10 @@ armors {
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
     S:END_STEEL <
+		End-Forged
+		Endthetic
+		Draconic
+		Spatial
      >
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
@@ -64,6 +68,9 @@ armors {
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
     S:EXOSKELETON <
+		Exotic
+		Plated
+		Exoskeletal
      >
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
@@ -121,6 +128,9 @@ armors {
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
     S:"IJ:PLATINUM" <
+		Shiny
+		Sturdy
+		Tough
      >
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
@@ -142,10 +152,10 @@ armors {
     # A list of material-based prefix names for the given armor material. May be empty. [default: [Iron], [Steel], [Ferrous], [Rusty], [Wrought Iron]]
     S:IRON <
         Iron
-        Steel
         Ferrous
         Rusty
         Wrought Iron
+		Battle-Scarred
      >
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
@@ -158,6 +168,9 @@ armors {
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
     S:KNIGHTMETAL <
+		Knightly
+		Honorable
+		Indestructable
      >
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
@@ -194,6 +207,10 @@ armors {
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
     S:REIN_EXOSKELETON <
+		Reinforced
+		Otherworldly
+		Dense
+		Stronk
      >
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
@@ -206,6 +223,11 @@ armors {
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
     S:SILK <
+		Infused
+		Magical
+		Manaweaved
+		Arcane
+		Mystical
      >
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
@@ -258,6 +280,9 @@ armors {
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
     S:"TF:PLATINUM" <
+		Shiny
+		Sturdy
+		Tough
      >
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
@@ -346,6 +371,10 @@ armors {
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
     S:slimy_bone <
+		Grimy
+		Slimed
+		Brittle
+		Oozing
      >
 
     # A list of material-based prefix names for the given armor material. May be empty. [default: ]
@@ -565,6 +594,7 @@ enchantments {
     "minecraft:depth_strider" {
         # The possible prefixes associated with this enchantment. [default: ]
         S:Prefixes <
+			Drowned
          >
 
         # The possible suffixes associated with this enchantment. [default: ]
@@ -575,6 +605,7 @@ enchantments {
     "minecraft:frost_walker" {
         # The possible prefixes associated with this enchantment. [default: ]
         S:Prefixes <
+			Frozen
          >
 
         # The possible suffixes associated with this enchantment. [default: ]
@@ -595,30 +626,36 @@ enchantments {
     "openblocks:explosive" {
         # The possible prefixes associated with this enchantment. [default: ]
         S:Prefixes <
+			Explosive
          >
 
         # The possible suffixes associated with this enchantment. [default: ]
         S:Suffixes <
+			Explosions
          >
     }
 
     "openblocks:last_stand" {
         # The possible prefixes associated with this enchantment. [default: ]
         S:Prefixes <
+			Indestructible
          >
 
         # The possible suffixes associated with this enchantment. [default: ]
         S:Suffixes <
+			Ultimate Protection
          >
     }
 
     "openblocks:flim_flam" {
         # The possible prefixes associated with this enchantment. [default: ]
         S:Prefixes <
+			Unsafe
          >
 
         # The possible suffixes associated with this enchantment. [default: ]
         S:Suffixes <
+			Unhealty Activities
          >
     }
 
@@ -807,22 +844,45 @@ enchantments {
     }
 
     "ebwizardry:flaming_weapon" {
-        # The possible prefixes associated with this enchantment. [default: ]
+        # The possible prefixes associated with this enchantment. [default: [Fiery], [Fiery Dragon], [Fire], [Burning], [Hot], [Volcanic], [Lava], [Dragon], [Tree-Slaying]]
         S:Prefixes <
+            Fiery
+            Fiery Dragon
+            Fire
+            Burning
+            Hot
+            Volcanic
+            Lava
+            Dragon
+            Tree-Slaying
          >
 
-        # The possible suffixes associated with this enchantment. [default: ]
+        # The possible suffixes associated with this enchantment. [default: [Fire], [The Fire Dragon], [Flame], [Burning], [Heat], [Volcanoes], [Lava], [The Dragon], [Tree Slaying]]
         S:Suffixes <
+            Fire
+            The Fire Dragon
+            Flame
+            Burning
+            Heat
+            Volcanoes
+            Lava
+            The Dragon
+            Tree Slaying
          >
     }
 
     "ebwizardry:freezing_weapon" {
-        # The possible prefixes associated with this enchantment. [default: ]
+        # The possible prefixes associated with this enchantment. [default: [Fiery], [Fiery Dragon], [Fire], [Burning], [Hot], [Volcanic], [Lava], [Dragon], [Tree-Slaying]]
         S:Prefixes <
+            Icy
+            Frozen
          >
 
-        # The possible suffixes associated with this enchantment. [default: ]
+        # The possible suffixes associated with this enchantment. [default: [Fire], [The Fire Dragon], [Flame], [Burning], [Heat], [Volcanoes], [Lava], [The Dragon], [Tree Slaying]]
         S:Suffixes <
+            Ice
+			Blizzards
+			Snowstorms
          >
     }
 
@@ -839,6 +899,7 @@ enchantments {
     "ebwizardry:frost_protection" {
         # The possible prefixes associated with this enchantment. [default: ]
         S:Prefixes <
+		Frost-Resistant
          >
 
         # The possible suffixes associated with this enchantment. [default: ]
@@ -849,6 +910,7 @@ enchantments {
     "ebwizardry:shock_protection" {
         # The possible prefixes associated with this enchantment. [default: ]
         S:Prefixes <
+		Shock-Resistant
          >
 
         # The possible suffixes associated with this enchantment. [default: ]
@@ -859,10 +921,12 @@ enchantments {
     "endercore:xpboost" {
         # The possible prefixes associated with this enchantment. [default: ]
         S:Prefixes <
+			Experienced
          >
 
         # The possible suffixes associated with this enchantment. [default: ]
         S:Suffixes <
+			Experience
          >
     }
 
@@ -1495,7 +1559,20 @@ entity {
     pleb
     o
     roa
-
+	shad
+	ows
+	oof
+	me
+	legs
+	fell
+	off
+	help
+	me
+	boi
+	ags
+	let
+	mea
+	aks
      >
 
     # A list of full names, which are used in the generation of boss names. May be empty only if name parts is not empty. [default: [Albert], [Andrew], [Anderson], [Andy], [Allan], [Arthur], [Aaron], [Allison], [Arielle], [Amanda], [Anne], [Annie], [Amy], [Alana], [Brandon], [Brady], [Bernard], [Ben], [Benjamin], [Bob], [Bobette], [Brooke], [Brandy], [Beatrice], [Bea], [Bella], [Becky], [Carlton], [Carl], [Calvin], [Cameron], [Carson], [Chase], [Cassandra], [Cassie], [Cas], [Carol], [Carly], [Cherise], [Charlotte], [Cheryl], [Chasity], [Danny], [Drake], [Daniel], [Derrel], [David], [Dave], [Donovan], [Don], [Donald], [Drew], [Derrick], [Darla], [Donna], [Dora], [Danielle], [Edward], [Elliot], [Ed], [Edson], [Elton], [Eddison], [Earl], [Eric], [Ericson], [Eddie], [Ediovany], [Emma], [Elizabeth], [Eliza], [Esperanza], [Esper], [Esmeralda], [Emi], [Emily], [Elaine], [Fernando], [Ferdinand], [Fred], [Feddie], [Fredward], [Frank], [Franklin], [Felix], [Felicia], [Fran], [Greg], [Gregory], [George], [Gerald], [Gina], [Geraldine], [Gabby], [Hendrix], [Henry], [Hobbes], [Herbert], [Heath], [Henderson], [Helga], [Hera], [Helen], [Helena], [Hannah], [Ike], [Issac], [Israel], [Ismael], [Irlanda], [Isabelle], [Irene], [Irenia], [Jimmy], [Jim], [Justin], [Jacob], [Jake], [Jon], [Johnson], [Jonny], [Jonathan], [Josh], [Joshua], [Julian], [Jesus], [Jericho], [Jeb], [Jess], [Joan], [Jill], [Jillian], [Jessica], [Jennifer], [Jenny], [Jen], [Judy], [Kenneth], [Kenny], [Ken], [Keith], [Kevin], [Karen], [Kassandra], [Kassie], [Leonard], [Leo], [Leroy], [Lee], [Lenny], [Luke], [Lucas], [Liam], [Lorraine], [Latasha], [Lauren], [Laquisha], [Livia], [Lydia], [Lila], [Lilly], [Lillian], [Lilith], [Lana], [Mason], [Mike], [Mickey], [Mario], [Manny], [Mark], [Marcus], [Martin], [Marty], [Matthew], [Matt], [Max], [Maximillian], [Marth], [Mia], [Marriah], [Maddison], [Maddie], [Marissa], [Miranda], [Mary], [Martha], [Melonie], [Melody], [Mel], [Minnie], [Nathan], [Nathaniel], [Nate], [Ned], [Nick], [Norman], [Nicholas], [Natasha], [Nicki], [Nora], [Nelly], [Nina], [Orville], [Oliver], [Orlando], [Owen], [Olsen], [Odin], [Olaf], [Ortega], [Olivia], [Patrick], [Pat], [Paul], [Perry], [Pinnochio], [Patrice], [Patricia], [Pennie], [Petunia], [Patti], [Pernelle], [Quade], [Quincy], [Quentin], [Quinn], [Roberto], [Robbie], [Rob], [Robert], [Roy], [Roland], [Ronald], [Richard], [Rick], [Ricky], [Rose], [Rosa], [Rhonda], [Rebecca], [Roberta], [Sparky], [Shiloh], [Stephen], [Steve], [Saul], [Sheen], [Shane], [Sean], [Sampson], [Samuel], [Sammy], [Stefan], [Sasha], [Sam], [Susan], [Suzy], [Shelby], [Samantha], [Sheila], [Sharon], [Sally], [Stephanie], [Sandra], [Sandy], [Sage], [Tim], [Thomas], [Thompson], [Tyson], [Tyler], [Tom], [Tyrone], [Timmothy], [Tamara], [Tabby], [Tabitha], [Tessa], [Tiara], [Tyra], [Uriel], [Ursala], [Uma], [Victor], [Vincent], [Vince], [Vance], [Vinny], [Velma], [Victoria], [Veronica], [Wilson], [Wally], [Wallace], [Will], [Wilard], [William], [Wilhelm], [Xavier], [Xandra], [Young], [Yvonne], [Yolanda], [Zach], [Zachary]]
@@ -1522,6 +1599,7 @@ entity {
     Notso
     Drak
     Burntoasto
+	Hamburger Helper
     Funosto
     Tacosto
     Chairosto
@@ -1533,16 +1611,21 @@ entity {
     Dreadosto
     Funosto
     Beerosto
+	Shadows
      >
 
     # A list of prefixes, which are used in the generation of boss names. May be empty. [default: [Sir], [Mister], [Madam], [Doctor], [Father], [Mother]]
     S:Prefixes <
-        Sir
-        Mister
-        Madam
-        Doctor
-        Father
-        Mother
+        Darkostist
+		Captain
+		Daddy
+		First Lieutenant
+		Prince
+		Professor
+		Reverend
+		The Honorable
+		Dean
+		Commander
      >
 
     # A list of suffixes, which are used in the generation of boss names. A suffix is always preceeded by "The". May be empty. [default: [Mighty], [Supreme], [Superior], [Ultimate], [Lame], [Wimpy], [Curious], [Sneaky], [Pathetic], [Crying], [Eagle], [Errant], [Unholy], [Questionable], [Mean], [Hungry], [Thirsty], [Feeble], [Wise], [Sage], [Magical], [Mythical], [Legendary], [Not Very Nice], [Jerk], [Doctor], [Misunderstood], [Angry], [Knight], [Bishop], [Godly], [Special], [Toasty], [Shiny], [Shimmering], [Light], [Dark], [Odd-Smelling], [Funky], [Rock Smasher], [Son of Herobrine], [Cracked], [Sticky], [§kAlien§r], [Baby], [Manly], [Rough], [Scary], [Undoubtable], [Honest], [Non-Suspicious], [Boring], [Odd], [Lazy], [Super], [Nifty], [Ogre Slayer], [Pig Thief], [Dirt Digger], [Really Cool], [Doominator], [... Something]]
@@ -1574,13 +1657,15 @@ entity {
         Chairosto
         Dedosto
         Riposto
-
-Coffeeosto
-Purposto
-Bananosto
-Dreadosto
-Funosto
-Beerosto
+		Coffeeosto
+		Purposto
+		Bananosto
+		Dreadosto
+		Funosto
+		Beerosto
+		Steve-Slayer
+		Bad Modder
+		Pack Dev
      >
 }
 
@@ -1589,13 +1674,11 @@ items {
     # A list of root names for helms, used in the generation of item names. May not be empty. [default: [Helmet], [Cap], [Crown], [Great Helm], [Bassinet], [Sallet], [Close Helm], [Barbute]]
     S:Helms <
         Helmet
-        Cap
         Crown
         Great Helm
-        Bassinet
-        Sallet
-        Close Helm
-        Barbute
+        Darkohat
+		Facial Defense Unit
+		Cranial Safety Structure
      >
 
     # A list of root names for axes, used in the generation of item names. May not be empty. [default: [Axe], [Chopper], [Hatchet], [Tomahawk], [Cleaver], [Hacker], [Tree-Cutter], [Truncator]]
@@ -1603,11 +1686,10 @@ items {
         Axe
         Chopper
         Hatchet
-        Tomahawk
-        Cleaver
-        Hacker
-        Tree-Cutter
-        Truncator
+        Tree-Slayer
+        Skyfactory Utility Object
+		Tree-Stabber
+		Forest-Demolisher
      >
 
     # A list of root names for boots, used in the generation of item names. May not be empty. [default: [Boots], [Shoes], [Greaves], [Sabatons], [Sollerets]]
@@ -1616,7 +1698,9 @@ items {
         Shoes
         Greaves
         Sabatons
-        Sollerets
+		Toe Protectors
+		Safety Slippers
+		Comfy Sneakers
      >
 
     # A list of root names for bows, used in the generation of item names. May not be empty. [default: [Bow], [Shortbow], [Longbow], [Flatbow], [Recurve Bow], [Reflex Bow], [Self Bow], [Composite Bow], [Arrow-Flinger]]
@@ -1630,6 +1714,7 @@ items {
         Self Bow
         Composite Bow
         Arrow-Flinger
+		Shooty
      >
 
     # A list of root names for chestplates, used in the generation of item names. May not be empty. [default: [Chestplate], [Tunic], [Brigandine], [Hauberk], [Cuirass]]
@@ -1638,7 +1723,7 @@ items {
         Tunic
         Brigandine
         Hauberk
-        Cuirass
+        External Ribcage
      >
 
     # A list of root names for leggings, used in the generation of item names. May not be empty. [default: [Leggings], [Pants], [Tassets], [Cuisses], [Schynbalds]]
@@ -1647,7 +1732,7 @@ items {
         Pants
         Tassets
         Cuisses
-        Schynbalds
+        My Legs
      >
 
     # A list of root names for pickaxes, used in the generation of item names. May not be empty. [default: [Pickaxe], [Pick], [Mattock], [Rock-Smasher], [Miner]]
@@ -1657,6 +1742,7 @@ items {
         Mattock
         Rock-Smasher
         Miner
+		Ore-Hunter
      >
 
     # A list of root names for shovels, used in the generation of item names. May not be empty. [default: [Shovel], [Spade], [Digger], [Excavator], [Trowel], [Scoop]]
@@ -1667,6 +1753,7 @@ items {
         Excavator
         Trowel
         Scoop
+		Dirt-Remover
      >
 
     # A list of root names for swords, used in the generation of item names. May not be empty. [default: [Sword], [Cutter], [Slicer], [Dicer], [Knife], [Blade], [Machete], [Brand], [Claymore], [Cutlass], [Foil], [Dagger], [Glaive], [Rapier], [Saber], [Scimitar], [Shortsword], [Longsword], [Broadsword], [Calibur]]
@@ -1691,6 +1778,9 @@ items {
         Longsword
         Broadsword
         Calibur
+		Stabbing Implement
+		Sharp Arm
+		Knife-like Thing
      >
 }
 
@@ -1731,6 +1821,10 @@ tools {
 
     # A list of material-based prefix names for the given tool material. May be empty. [default: ]
     S:GIANTSTONE <
+	Thicc
+	Lorg
+	Extra Thicc
+	Gigantic
      >
 
     # A list of material-based prefix names for the given tool material. May be empty. [default: [Golden], [Gold], [Gilt], [Auric], [Ornate]]
@@ -1765,6 +1859,9 @@ tools {
 
     # A list of material-based prefix names for the given tool material. May be empty. [default: ]
     S:KNIGHTMETAL <
+		Knightly
+		Knighted
+		Royal
      >
 
     # A list of material-based prefix names for the given tool material. May be empty. [default: ]
@@ -1861,6 +1958,9 @@ tools {
 
     # A list of material-based prefix names for the given tool material. May be empty. [default: ]
     S:TFGLASS <
+		Glassy
+		Fragile
+		Shattered
      >
 
     # A list of material-based prefix names for the given tool material. May be empty. [default: ]
@@ -1877,6 +1977,7 @@ tools {
 
     # A list of material-based prefix names for the given tool material. May be empty. [default: ]
     S:WASP_SWORD <
+		Unfriendly
      >
 
     # A list of material-based prefix names for the given tool material. May be empty. [default: [Wooden], [Wood], [Hardwood], [Balsa Wood], [Mahogany], [Plywood]]
@@ -1891,6 +1992,9 @@ tools {
 
     # A list of material-based prefix names for the given tool material. May be empty. [default: ]
     S:bone <
+		Sharp
+		Splintered
+		Undead
      >
 
     # A list of material-based prefix names for the given tool material. May be empty. [default: ]
@@ -1903,6 +2007,9 @@ tools {
 
     # A list of material-based prefix names for the given tool material. May be empty. [default: ]
     S:endSteel <
+		Endest
+		End-Forged
+		Draconic
      >
 
     # A list of material-based prefix names for the given tool material. May be empty. [default: ]

--- a/src/config/apotheosis/potion.cfg
+++ b/src/config/apotheosis/potion.cfg
@@ -2,7 +2,7 @@
 
 general {
     # The strength of Ancient Knowledge.  This multiplier determines how much additional xp is granted. [range: 1 ~ 2147483647, default: 10]
-    I:"Knowledge XP Multiplier"=10
+    I:"Knowledge XP Multiplier"=6
 }
 
 

--- a/src/config/apotheosis/spawner.cfg
+++ b/src/config/apotheosis/spawner.cfg
@@ -5,13 +5,13 @@ general {
     S:"Inverse Item"=minecraft:quartz
 
     # The level of silk touch needed to harvest a spawner.  Set to -1 to disable, 0 to always drop.  The enchantment module can increase the max level of silk touch. [range: -1 ~ 127, default: 1]
-    I:"Spawner Silk Level"=1
+    I:"Spawner Silk Level"=2
 }
 
 
 ignore_spawn_cap {
     # The item that applies this modifier. [default: minecraft:chorus_fruit]
-    S:item=minecraft:chorus_fruit
+    S:item=rats:chunky_cheese_token
 
     # The amount each item changes this stat. [range: -2147483648 ~ 2147483647, default: 2147483647]
     I:max_value=2147483647

--- a/src/scripts/crafttweaker/apoth_boss.zs
+++ b/src/scripts/crafttweaker/apoth_boss.zs
@@ -1,0 +1,122 @@
+import mods.apotheosis.BossArmor;
+
+BossArmor.removeSet("gold");
+BossArmor.removeSet("iron");
+BossArmor.removeSet("diamond");
+
+BossArmor.addArmorSet(0, "iron_tank", 
+<minecraft:iron_sword>, 
+<minecraft:shield>, 
+<minecraft:iron_boots>,
+<minecraft:iron_leggings>,
+<minecraft:iron_chestplate>,
+<minecraft:iron_helmet>);
+
+BossArmor.addArmorSet(0, "iron_zerk", 
+<minecraft:iron_axe>, 
+<minecraft:iron_axe>, 
+<minecraft:iron_boots>, 
+<minecraft:iron_leggings>,
+<minecraft:iron_chestplate>,
+<minecraft:chainmail_helmet>);
+
+BossArmor.addArmorSet(0, "bone", 
+<thebetweenlands:bone_sword>, 
+<thebetweenlands:bone_shield>, 
+<thebetweenlands:bone_boots>, 
+<thebetweenlands:bone_leggings>, 
+<thebetweenlands:bone_chestplate>, 
+<thebetweenlands:bone_helmet>);
+
+BossArmor.addArmorSet(1, "exo", 
+<erebus:wasp_sword>, 
+<erebus:exoskeleton_shield>, 
+<erebus:exoskeleton_boots>, 
+<erebus:exoskeleton_leggings>, 
+<erebus:exoskeleton_chestplate>, 
+<erebus:exoskeleton_helmet>);
+
+BossArmor.addArmorSet(1, "giant", 
+<twilightforest:giant_sword>, 
+<twilightforest:giant_sword>,
+<twilightforest:ironwood_boots>, 
+<twilightforest:ironwood_leggings>, 
+<twilightforest:ironwood_chestplate>, 
+<twilightforest:ironwood_helmet>);
+
+BossArmor.addPossibleWeapons("iron_tank", <minecraft:iron_axe> % 2, <minecraft:iron_pickaxe> % 1, <minecraft:iron_shovel> % 1);
+
+BossArmor.addArmorSet(1, "ice_mage", 
+<ebwizardry:apprentice_ice_wand>, 
+<ebwizardry:amulet_ice_immunity>,
+<ebwizardry:wizard_boots_ice>, 
+<ebwizardry:wizard_leggings_ice>, 
+<ebwizardry:wizard_robe_ice>, 
+<ebwizardry:wizard_hat_ice>);
+
+BossArmor.addArmorSet(1, "earth_mage", 
+<ebwizardry:apprentice_earth_wand>, 
+<ebwizardry:ring_earth_biome>,
+<ebwizardry:wizard_boots_earth>, 
+<ebwizardry:wizard_leggings_earth>, 
+<ebwizardry:wizard_robe_earth>, 
+<ebwizardry:wizard_hat_earth>);
+
+BossArmor.addArmorSet(1, "fire_mage", 
+<ebwizardry:apprentice_fire_wand>, 
+<ebwizardry:ring_combustion>,
+<ebwizardry:wizard_boots_fire>, 
+<ebwizardry:wizard_leggings_fire>, 
+<ebwizardry:wizard_robe_fire>, 
+<ebwizardry:wizard_hat_fire>);
+
+BossArmor.addArmorSet(2, "diamond", 
+<minecraft:diamond_sword>, 
+<ancientwarfarenpc:diamond_shield>, 
+<minecraft:diamond_boots>, 
+<minecraft:diamond_leggings>, 
+<minecraft:diamond_chestplate>,
+<minecraft:diamond_helmet>);
+
+BossArmor.addPossibleWeapons("diamond", <ancientwarfarenpc:diamond_spear>, <ancientwarfarenpc:diamond_halberd>, <ancientwarfarenpc:diamond_lance>);
+
+BossArmor.addArmorSet(2, "platinum", 
+<thermalfoundation:tool.sword_platinum>,
+<thermalfoundation:tool.shield_platinum>, 
+<thermalfoundation:armor.boots_platinum>, 
+<thermalfoundation:armor.legs_platinum>, 
+<thermalfoundation:armor.plate_platinum>, 
+<thermalfoundation:armor.helmet_platinum>);
+
+BossArmor.addArmorSet(1, "master_fire_mage", 
+<ebwizardry:master_fire_wand>, 
+<ebwizardry:ring_disintegration>,
+<ebwizardry:wizard_boots_fire>.withTag({legendary: 1 as byte}), 
+<ebwizardry:wizard_leggings_fire>.withTag({legendary: 1 as byte}), 
+<ebwizardry:wizard_robe_fire>.withTag({legendary: 1 as byte}), 
+<ebwizardry:wizard_hat_fire>.withTag({legendary: 1 as byte}));
+
+BossArmor.addArmorSet(3, "end_steel", 
+<enderio:item_end_steel_sword>,
+<enderio:item_end_steel_shield>,
+<enderio:item_end_steel_boots>, 
+<enderio:item_end_steel_leggings>, 
+<enderio:item_end_steel_chestplate>, 
+<enderio:item_end_steel_helmet>);
+
+BossArmor.addArmorSet(3, "reinforced_exo", 
+<mowziesmobs:wrought_axe>, 
+<erebus:rein_exoskeleton_shield>, 
+<erebus:rein_exoskeleton_boots>, 
+<erebus:rein_exoskeleton_leggings>, 
+<erebus:rein_exoskeleton_chestplate>, 
+<erebus:rein_exoskeleton_helmet>);
+
+BossArmor.addArmorSet(4, "glass_man", 
+<twilightforest:glass_sword>.withTag({ench: [{lvl: 10 as short, id: 34}]}),
+<twilightforest:knightmetal_shield>,
+<twilightforest:knightmetal_boots>, 
+<twilightforest:knightmetal_leggings>, 
+<twilightforest:knightmetal_chestplate>, 
+<twilightforest:knightmetal_helmet>);
+

--- a/src/scripts/crafttweaker/apoth_boss.zs
+++ b/src/scripts/crafttweaker/apoth_boss.zs
@@ -88,7 +88,7 @@ BossArmor.addArmorSet(2, "platinum",
 <thermalfoundation:armor.plate_platinum>, 
 <thermalfoundation:armor.helmet_platinum>);
 
-BossArmor.addArmorSet(1, "master_fire_mage", 
+BossArmor.addArmorSet(3, "master_fire_mage", 
 <ebwizardry:master_fire_wand>, 
 <ebwizardry:ring_disintegration>,
 <ebwizardry:wizard_boots_fire>.withTag({legendary: 1 as byte}), 


### PR DESCRIPTION
Blacklists some ded enchantments (shimmer, duplicate soulbound, autosmelt, etc)
Adds extra mobs to the boss, swarm, and brutal spawner lists.
Make spawners take silk touch II to harvest, also make that obtainable.
Added more names.
Added more boss armor sets.
Nerfed potion of ancient knowledge
Did some other things that I've forgotten.

Note that these changes require Apotheosis 1.11.4+