### PR TITLE
More apoth configs

### DIFF
--- a/src/config/apotheosis/deadly.cfg
+++ b/src/config/apotheosis/deadly.cfg
@@ -26,7 +26,7 @@ bosses {
     S:"Max Damage Bonus"=5.0
 
     # The max amount boss health is multiplied by.  Base hp * factor = final hp. [range: 0.0 ~ 2.14748365E9, default: 10.0]
-    S:"Max Health Multiplier"=25.0
+    S:"Max Health Multiplier"=4.0
 
     # The max amount of knockback resist bosses have. [range: 0.0 ~ 2.14748365E9, default: 1.0]
     S:"Max Knockback Resist"=1.0
@@ -44,7 +44,7 @@ bosses {
     S:"Min Damage Bonus"=0.9
 
     # The min amount boss health is multiplied by.  Base hp * factor = final hp. [range: 0.0 ~ 2.14748365E9, default: 2.5]
-    S:"Min Health Multiplier"=2.5
+    S:"Min Health Multiplier"=2.0
 
     # The min amount of knockback resist bosses have. [range: 0.0 ~ 2.14748365E9, default: 0.5]
     S:"Min Knockback Resist"=0.5

--- a/src/config/apotheosis/deadly.cfg
+++ b/src/config/apotheosis/deadly.cfg
@@ -17,7 +17,7 @@ bosses {
      >
 
     # The percent chance a boss has fire resistance. [range: 0.0 ~ 3.4028235E38, default: 0.5]
-    B:"Fire Resistance"=true
+    S:"Fire Resistance"=1.0
 
     # The level up chance, this is rolled once per number of levels.  Levels determine gear. [range: 0.0 ~ 2.14748365E9, default: 0.4]
     S:"Level Up Chance"=0.5
@@ -65,7 +65,7 @@ bosses {
     S:"Random Potion Chance"=0.45
 
     # The percent chance a boss has water breathing. [range: 0.0 ~ 3.4028235E38, default: 1.0]
-    B:"Water Breathing"=true
+    S:"Water Breathing"=10
 }
 
 


### PR DESCRIPTION
* Tone down max possible boss hp values (25x -> 4x) because the beneath is applying an additional 2x multiplier, and every boss in the beneath currently has 1024 hp